### PR TITLE
Alternate version that uses more bash built-ins

### DIFF
--- a/src/sshy.sh
+++ b/src/sshy.sh
@@ -1,147 +1,120 @@
-#!/bin/bash
+#!/usr/bin/env bash
+description="Usage: $0 [OPTIONS]
 
-# SSHy is a simple script to list SSH logins in a more human-readable format.
-# It uses the /var/log/auth.log file, and optionally the /var/log/auth.log.1 file.
+SSHy is a simple script to list SSH logins in a more human-readable format.
+It uses the file at /var/log/auth.log file, and optionally auth.log.* files.
 
-# Time the execution of the script
-start=$(date +%s.%N)
+Options:
+    -i,  --include-old
+        Include rotated logs (numberbed backups such as auth.log.1, etc.)
+    -r,  --reverse-output
+        Sort entries by newest to oldest instead of oldest to newest
+    -24, --24-hour
+        Uses 24-hour format instead of 12-hour format for timestamps
+    -t,  --timer
+        Prints the script's execution time
+    -h,  --help
+        Displays this help message
+"
+AUTH_LOG_LOCATION=/var/log/auth.log
 
-# Parse command line arguments
-while [ "$1" != "" ]; do
-    case $1 in
-        -i | --include-old )
-            include_old=1
-            ;;
-        -r | --reverse-output )
-            reverse_output=1
-            ;;
-        -24 | --24-hour )
-            twfr_format=1
-            ;;
-        -t | --timer )
-            timer=1
-            ;;
-        -h | --help )
-            help=1
-            ;;
-        * )
-            help=1
-    esac
-    shift
-done
+print_logins() {
+    for file in "$@"; do
+        msg "Reading '$file'..."
+        # If the file exists and is readable
+        if [ -r "$file" ]; then
+            # For every line that indicates a successful login
+            while read -r line; do
+                pattern="($date_pattern) .* sshd\[([0-9]+)\]: Accepted \((publickey|password)\) for (\w+) from ([0-9.]+)"
 
-# If the user specified the help option, print the help message and exit
-if [ -n "$help" ]; then
-    echo "Usage: ./sshy.sh [OPTIONS]"
-    echo "Options:"
-    echo "  -i, --include-old: Includes logs from auth.log.1, where older logs are stored"
-    echo "  -r, --reverse-output: Sorts entries by newest to oldest instead of oldest to newest"
-    echo "  -24, --24-hour: Uses 24-hour format instead of 12-hour format for timestamps"
-    echo "  -t, --timer: Prints the script's execution time"
-    echo "  -h, --help: Displays this help message"
-    exit 0
-fi
+                if [[ "$line" =~ $pattern ]]; then
+                    # Get the login data
+                    username=${BASH_REMATCH[4]}
+                    ip=${BASH_REMATCH[5]}
+                    date=${BASH_REMATCH[1]}
+                    authtype=${BASH_REMATCH[3]}
 
-# Get the first line of the auth.log file to choose the correct timestamp format
-first_line=$(head -n 1 /var/log/auth.log)
+                    # Turn the date into a more human-readable format, e.g. "01/16/2023 12:00 PM"
+                    # or "01/16/2023 12:00" if the user specified the --24-hour option
+                    format="+%m/%d/%Y %I:%M %p"
+                    if [ -n "$twfr_format" ]; then
+                        format="+%m/%d/%Y %H:%M"
+                    fi 
+                    date=$(date -d "$date" "$format")
 
-echo "Checking timestamp format..."
-
-# If the auth.log file uses the "Jan 16 12:00:00" timestamp format
-if [[ $(grep -oP "^\w+\s+\d+ [\d:]{8}" <<< "$first_line") ]]; then
-    echo "Using the standard timestamp format."
-    date_pattern="^\w+\s+\d+ [\d:]{8}"
-# If the auth.log file uses the "2023-01-16T12:00:00.123456-03:00" timestamp format
-elif [[ $(grep -oP "^\d+-\d+-\d+T[\d:]{8}\.\d+-\d+:\d+" <<< "$first_line") ]]; then
-    echo "Using the alternate timestamp format."
-    date_pattern="^\d+-\d+-\d+T[\d:]{8}\.\d+-\d+:\d+"
-# If the auth.log file uses an unknown timestamp format
-else
-    echo "Error: Could not determine the timestamp format of your auth.log file." >&2
-    exit 1
-fi
-
-input_files=()
-
-# If the user specified the --include-old option, include logs from auth.log.1
-if [ -n "$include_old" ]; then
-    input_files+=("/var/log/auth.log.1")
-fi
-
-# Always include logs from auth.log
-input_files+=("/var/log/auth.log")
-
-output_lines=()
-
-for file in "${input_files[@]}"
-do
-    echo "Reading $file..."
-    
-    # If the file exists
-    if [ -f "$file" ]; then
-        # For every line that indicates a successful login
-        while read -r line
-        do
-            match=$(grep -oP "($date_pattern .* sshd\[[\d]+\]: Accepted (publickey|password) for \w+ from [\d.]+)" <<< "$line")
-
-            if [ -n "$match" ]; then
-                # Get the username
-                username=$(grep -oP '(?<=for )\w+' <<< "$match")
-                # Get the IP address
-                ip=$(grep -oP '((\d+\.){3}\d+)' <<< "$match")
-                # Get the date
-                date=$(grep -oP "($date_pattern)" <<< "$match")
-                # Get the authentication method
-                authtype=$(grep -oP '(password|publickey)' <<< "$match")
-
-                # Turn the date into a more human-readable format, e.g. "01/16/2023 12:00 PM"
-                # or "01/16/2023 12:00" if the user specified the --24-hour option
-                if [ -n "$twfr_format" ]; then
-                    date=$(date -d "$date" "+%m/%d/%Y %H:%M")
-                else
-                    date=$(date -d "$date" "+%m/%d/%Y %I:%M %p")
+                    # Summarize the login neatly
+                    echo "[$date] $username logged in from $ip using a $authtype"
                 fi
+            done < "$file"
+        # If the file does not exist
+        else
+            echo "Error: $file does not exist on your system or isn't readable." >&2
+            return 2
+        fi
+    done
+}
 
-                # Turn authtype from "password" to "a password" to "a key" respectively
-                if [ "$authtype" = "password" ]; then
-                    authtype="a password"
-                else
-                    authtype="a key"
-                fi
-
-                # Print the information
-                output_lines+=("[$date] $username logged in from $ip using $authtype")
-            fi
-        done < "$file"
-    # If the file does not exist
-    else
-        echo "Error: $file does not exist on your system." >&2
-        exit 2
+run_sshy() {
+    date_pattern=$(determine_timestamp_format "$AUTH_LOG_LOCATION")
+    if [ -z "$date_pattern" ]; then
+        msg "Error: Could not determine the timestamp format of your auth.log file."
+        return 1
     fi
-done
 
-echo
+    input_files=("$AUTH_LOG_LOCATION")
+    if [ -n "$include_old" ]; then
+        # The user specified --include-old, so include numbered logfiles like auth.log.1 etc.
+        input_files=("${input_files[0]}."*)
+    fi
 
-# Print the output lines
-# If the user specified the --reverse-output option, reverse the order
-if [ -n "$reverse_output" ]; then
-    for ((i=${#output_lines[@]}-1; i>=0; i--))
-    do
-        echo "${output_lines[$i]}"
+    # Print the output lines
+    if [ -n "$reverse_output" ]; then
+        # If the user specified the --reverse-output option, reverse the order
+        print_logins "${input_files[@]}" | tac
+    else
+        print_logins "${input_files[@]}" 
+    fi
+}
+
+determine_timestamp_format() {
+    msg "Checking timestamp format..."
+    read -r first_line < "$1"
+
+    standard_pattern="^\w+\s+[0-9]+ [0-9]{2}:[0-9]{2}:[0-9]{2}";   # "Jan 16 12:00:00"
+    [[ "$first_line" =~ $standard_pattern ]] &&
+        msg "Using the standard timestamp format ($first_line)." &&
+        echo "$standard_pattern" &&
+        return 0
+
+    alternate_pattern="^[0-9]+-[0-9]+-[0-9]+T[0-9:]{8}\.[0-9]+-[0-9]+:[0-9]+";  # "2023-01-16T12:00:00.123456-03:00" 
+    [[ "$first_line" =~ $alternate_pattern ]] &&
+        msg "Using the alternate timestamp format ($first_line)." &&
+        echo "$alternate_pattern"
+}
+
+msg() { echo "$*" 1>&2; }
+
+if [ "$0" = "$BASH_SOURCE" ]; then
+    # Parse command line arguments
+    for arg in "$@"; do
+        case $arg in
+            -i | --include-old )
+                include_old=1
+                ;;
+            -r | --reverse-output )
+                reverse_output=1
+                ;;
+            -24 | --24-hour )
+                twfr_format=1
+                ;;
+            -t | --timer )
+                timer="time"
+                ;;
+            -h | --help | * )
+                msg "$description"
+                exit 0
+                ;;
+        esac
     done
-else
-    for line in "${output_lines[@]}"
-    do
-        echo "$line"
-    done
+    eval "${timer:-} run_sshy"  # eval for time builtin instead of time command
 fi
-
-# If the user specified the --timer option, print the execution time
-if [ -n "$timer" ]; then
-    echo
-    end=$(date +%s.%N)
-    runtime=$(echo "$end - $start" | bc)
-    echo "Execution time: $runtime seconds"
-fi
-
-exit 0


### PR DESCRIPTION
Hi, I did a little re-write of sshy. I hope you don't mind.

What this does differently:

 - `/usr/bin/env bash` hashbang works on distributions like NixOS, where bash is not in `/usr/bin`.
 - Refactoring the functionality into functions allows to `source sshy` in another bash-script and use its functions like from a library, it also breaks it down into smaller, more digestible parts.
 - Using `tac` for output reversal, means we don't have to store the whole in a bash array, it's also less code.
 - Using the `time` bash-builtin for benchmarking is both more precise and less code.
 - Using bash's builtin regular expressions is faster than calling grep a lot (older bash versions may not support them).
 - `read` is also a bash built-in and should be faster than  calling `head` to get the first line.
 - Printing the messages that are meant for the user to `stderr` even if they are not strictly errors is more POSIX-conform and allows to separate the data from messages directed to the user. You will see almost all UNIX-tools do it that way, because you want to be able to pipe the data to another program and process it, but the user messages should bubble up to the user and not confuse a program and make extra handling of those irregularities necessary later down the pipe.  
 - I shortened a few of the messages and comments, especially where they were redundant with the code. The more code you read, the more you appreciate brevity as long as things remain clear.
 - Using `--long-options` when you call other commands is better in scripts, because it makes them more readable and people don't have to look up less of what things like `grep -oP -m1 -s ...` does, short options are, of course, faster in interactive sessions that tend to be ephemeral.
 
Hope you like it, and if not, at least learned a bit.